### PR TITLE
Improve vue-i18n example

### DIFF
--- a/examples/vue-i18n/utils/i18n.ts
+++ b/examples/vue-i18n/utils/i18n.ts
@@ -7,5 +7,6 @@ export type I18nSchema = typeof schema;
 export type I18nLocales = 'en' | 'ko';
 
 export default createI18n<[I18nSchema], I18nLocales>({
-  messages: messages as any,
+  locale: browser.i18n.getUILanguage(),
+  messages: messages as Record<I18nLocales, I18nSchema>,
 });


### PR DESCRIPTION
## Problem

When running  the `vue-i18n` example, and switching the browser to korean using this command (on Linux):

```
LANGUAGE=ko pnpm dev
```

The translations from `vue-i18n` are still in english, although "vanilla" translation are in korean:

![image](https://github.com/wxt-dev/wxt-examples/assets/19571875/80a13d40-c9d4-45a8-b0ef-8fd7a6a11f30)

![image](https://github.com/wxt-dev/wxt-examples/assets/19571875/36f9d658-777c-4fd0-b7a3-a44993699c5c)

## Solution

Give the locale to `vue-i18n` in `i18n.ts` works fine.

## Additional info

Using `as any` for `messages` isn't friendly with recommended Typescript eslint rules, switching to `as Record<I18nLocales, I18nSchema>` is more accurate.

Thanks for your work!
